### PR TITLE
Automate the building process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-build/README.pdf
+build/
+node_modules/
+temp/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,84 @@
+var gulp          = require('gulp');
+var markdownpdf   = require('gulp-markdown-pdf');
+var path          = require('path');
+var replace       = require('gulp-replace');
+var package       = require('./package.json');
+var rename        = require('gulp-rename');
+var rimraf        = require('gulp-rimraf');
+var runSequence   = require('run-sequence');
+var glob          = require('glob');
+
+var TITLE = 'AngularJS in Patterns';
+
+function genericTask(lang){
+
+  gulp.task('generate:pdf:' + lang, function() {
+
+    var files = ['./temp/*.md'];
+    if (lang === 'eng'){
+      files = './temp/README.md'; 
+    }
+    else if(lang !== 'all'){
+      files = ['./temp/*-'+lang+'.md'];
+    }
+
+    return gulp.src(files)
+        .pipe(markdownpdf({
+          cwd: path.resolve('./temp/'),
+          layout: 'github'
+        }))
+        .on('error', function(err){
+            gutil.log(gutil.colors.red('doc task failed'), err);
+        })
+        .pipe(rename(function (path) {
+          var lang = 'ENG';
+          if(path.basename.indexOf('-') >= 0){
+            lang = path.basename.replace('README-', '').toUpperCase();
+          }
+          path.basename = TITLE + ' ('+lang+')';
+          path.extname = '.pdf'
+        }))
+        .pipe(gulp.dest('./build/'));
+  });
+
+}
+
+// build custom tasks for i18n
+
+glob.sync('./temp/README-*.md').map(function(file){
+  
+  return file.replace('README-', '');
+
+}).concat(['all', 'eng']).forEach(function(lang){
+  
+  genericTask(lang);
+  gulp.task('doc:pdf:'+lang, function(cb){
+    runSequence('clean', ['copy:images', 'copy:md'], 'generate:pdf:'+lang, cb);
+  });
+
+});
+
+gulp.task('default', function(cb){
+  runSequence('clean', ['copy:images', 'copy:md'], 'doc:pdf:all', cb);
+});
+
+gulp.task('copy:md', function(){
+  return gulp.src(['README.md', 'i18n/README-*.md'])
+      
+      // @todo I have no idea where should the TOC go?!
+      // for now, let's keep the TOC content and remove these markers
+      .pipe(replace('<!--toc-->', ''))
+      .pipe(replace('<!--endtoc-->', ''))
+
+      // preapre the image paths for the renderer 
+      .pipe(replace(/https:\/\/rawgit.com\/mgechev\/angularjs-in-patterns\/master\/images/g, '.'))
+      .pipe(gulp.dest('./temp/'));
+});
+
+gulp.task('copy:images', function(){
+  return gulp.src(['images/*.svg','meta.json']).pipe(gulp.dest('./temp'));
+});
+
+gulp.task('clean', function() {
+  return gulp.src('./temp/', { read: false }).pipe(rimraf());
+});

--- a/package.json
+++ b/package.json
@@ -11,10 +11,22 @@
     "url": "git://github.com/mgechev/angularjs-patterns.git"
   },
   "author": "mgechev",
+  "contributors": [{ 
+    "name" : "Wassim Chegham", 
+    "email" : "maneki.nekko@gmail.com", 
+    "url" : "https://github.com/manekinekko/"
+  }],
   "license": "MIT",
   "gitHead": "2009434a6dfdbe5f06f81253fb853840af753b36",
   "readmeFilename": "README.md",
   "devDependencies": {
-    "markdown-styles": "https://github.com/mgechev/markdown-styles/tarball/master"
+    "glob": "^5.0.14",
+    "gulp": "^3.9.0",
+    "gulp-markdown-pdf": "https://github.com/manekinekko/gulp-markdown-pdf.git#master",
+    "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.5.3",
+    "gulp-rimraf": "^0.1.1",
+    "markdown-styles": "https://github.com/mgechev/markdown-styles/tarball/master",
+    "run-sequence": "^1.1.1"
   }
 }


### PR DESCRIPTION
Hi @mgechev 
As discussed in issue https://github.com/mgechev/angularjs-in-patterns/issues/7, here is my first attempt to automate the build process.

### explanation

1) get the update from my fork
2) run npm install
3) run gulp (default task)

You will get a PDF file — in the ```./build/``` folder — of the main ```README.md``` (the english version) and all ```README-XX-YY.md``` in the i18n folder.

You can also generate separate PDF file per language. The gulp file analyses the .```/i18n``` folder and create a task for each ```README-XX-YY.md``` file it founds. For instance:

```sh
$ gulp doc:pdf:all # will generate all languages (default task)
$ gulp doc:pdf:eng # only english
$ gulp doc:pdf:ja_jp # only japanese
```

The generated PDFs are named as follwing: ```AngularJS in Patterns (LANG)```. 
For instance: ```AngularJS in Patterns (ENG)``` or ```AngularJS in Patterns (JA-JP)```. 
It is configurable in the ```gulpfile.js```.

Please let me know if this what you wanted ^^
Enjoy.

PS: about the translation enhancement, I will start it asap ;)
